### PR TITLE
Fix trivial typo in on_timeout

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -140,7 +140,7 @@ static gint on_timeout(gpointer user_data) {
         if (r < 0) {
             snd_mixer_close(app_data->mixer);
             app_data->mixer = NULL;
-            printf("disonnected.\n");
+            printf("Disconnected.\n");
             reset_alsa_mixer_elems(app_data);
         }
     }


### PR DESCRIPTION
Change the message 'disonnected' to 'Disconnected'.
Add the missing 'c', and capitalise it to match 'Connected'.

It's a small and picky thing, but typos grab my attention.